### PR TITLE
BUG FIXED: weapon models showed for both player when one of the player clicked the pre-defined key binds, rather than only the player that clicked the key binds.

### DIFF
--- a/Player.gd
+++ b/Player.gd
@@ -27,9 +27,6 @@ enum DynamicCameraViewToggleAction {
 @onready var tpp_ak47: Node3D = $TPPCamera/TPPAK47
 @onready var tpp_knife: Node3D = $TPPCamera/TPPKnife
 
-# Multiplayer Synchronizer
-@onready var multiplayer_sync: MultiplayerSynchronizer = $MultiplayerSynchronizer
-
 # Animations
 @onready var anim_player: AnimationPlayer = $AnimationPlayer
 
@@ -56,15 +53,6 @@ var is_fpp: bool = true
 # Track the current weapon
 var current_weapon: String = ""
 
-# Store initial visibility states
-var initial_fpp_pistol_visible: bool = false
-var initial_fpp_ak47_visible: bool = false
-var initial_fpp_knife_visible: bool = false
-
-var initial_tpp_pistol_visible: bool = false
-var initial_tpp_ak47_visible: bool = false
-var initial_tpp_knife_visible: bool = false
-
 
 func _enter_tree():
 	set_multiplayer_authority(str(name).to_int())
@@ -79,15 +67,6 @@ func _ready():
 	if not is_multiplayer_authority(): return
 	
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
-	
-		# Store initial visibility states
-	initial_fpp_pistol_visible = fpp_pistol.visible
-	initial_fpp_ak47_visible = fpp_ak47.visible
-	initial_fpp_knife_visible = fpp_knife.visible
-
-	initial_tpp_pistol_visible = tpp_pistol.visible
-	initial_tpp_ak47_visible = tpp_ak47.visible
-	initial_tpp_knife_visible = tpp_knife.visible
 	
 	# Initialize camera and gun visibility based on the editor setting
 	update_camera_visibility()
@@ -233,7 +212,6 @@ func receive_damage():
 		health_changed.emit(health)
 
 
-
 func _on_animation_player_animation_finished(anim_name):
 	if anim_name == "shoot":
 		anim_player.play("idle")
@@ -242,6 +220,7 @@ func _on_animation_player_animation_finished(anim_name):
 func add_health(additional_health):
 	health += additional_health
 	health_changed.emit(health)
+
 
 func add_ammo(additional_ammo):
 	current_ammo += additional_ammo
@@ -255,7 +234,7 @@ func add_ammo(additional_ammo):
 		#body.add_health(HEALTH_AMOUNTS)
 
 
-# Handle weapon switching based on the key inputs
+# Handle weapon switching bas	ed on the key inputs
 func _on_weapon_switched(weapon_name):
 	print("Switched to weapon: %s" % weapon_name)
 	current_weapon = weapon_name
@@ -275,37 +254,39 @@ func update_camera_visibility():
 
 # Update the visibility of guns when player changed the camera view based on their preferrance
 func update_weapon_model_visibility():
-	# Hide all weapons first
-	fpp_pistol.visible = initial_fpp_pistol_visible
-	fpp_ak47.visible = initial_fpp_ak47_visible
-	fpp_knife.visible = initial_fpp_knife_visible
-	tpp_pistol.visible = initial_tpp_pistol_visible
-	tpp_ak47.visible = initial_tpp_ak47_visible
-	tpp_knife.visible = initial_tpp_knife_visible
+	print("Updating weapon model visibility")
 
-	# Show the correct weapon based on the current weapon and camera view state
-	if is_fpp:
-		if current_weapon == "Glock-19":
-			fpp_pistol.visible = true
-		elif current_weapon == "AK-47":
-			fpp_ak47.visible = true
-		elif current_weapon == "Knife":
-			fpp_knife.visible = true
-	else:
-		if current_weapon == "Glock-19":
-			tpp_pistol.visible = true
-		elif current_weapon == "AK-47":
-			tpp_ak47.visible = true
-		elif current_weapon == "Knife":
-			tpp_knife.visible = true
+	# Hide all weapon models
+	fpp_pistol.visible = false
+	fpp_ak47.visible = false
+	fpp_knife.visible = false
+	tpp_pistol.visible = false
+	tpp_ak47.visible = false
+	tpp_knife.visible = false
 
-	# Synchronize visibility for multiplayer
-	# TODO: Not worked yet. DOn't touch it for now. I will fix it (Binh)
+	# Show the weapon model that corresponds to the currently selected weapon and is owned by the current player
 	if is_multiplayer_authority():
-		multiplayer_sync.set_visibility_for(multiplayer.get_unique_id(), fpp_pistol.visible)
-		multiplayer_sync.set_visibility_for(multiplayer.get_unique_id(), fpp_ak47.visible)
-		multiplayer_sync.set_visibility_for(multiplayer.get_unique_id(), fpp_knife.visible)
-		multiplayer_sync.set_visibility_for(multiplayer.get_unique_id(), tpp_pistol.visible)
-		multiplayer_sync.set_visibility_for(multiplayer.get_unique_id(), tpp_ak47.visible)
-		multiplayer_sync.set_visibility_for(multiplayer.get_unique_id(), tpp_knife.visible)
-		
+		match current_weapon:
+			"Glock-19":
+				if is_fpp:
+					fpp_pistol.visible = true
+				else:
+					tpp_pistol.visible = true
+			"AK-47":
+				if is_fpp:
+					fpp_ak47.visible = true
+				else:
+					tpp_ak47.visible = true
+			"Knife":
+				if is_fpp:
+					fpp_knife.visible = true
+				else:
+					tpp_knife.visible = true
+
+	print("FPP Pistol Visible: ", fpp_pistol.visible)
+	print("FPP AK47 Visible: ", fpp_ak47.visible)
+	print("FPP Knife Visible: ", fpp_knife.visible)
+
+	print("TPP Pistol Visible: ", tpp_pistol.visible)
+	print("TPP AK47 Visible: ", tpp_ak47.visible)
+	print("TPP Knife Visible: ", tpp_knife.visible)

--- a/Player.gd
+++ b/Player.gd
@@ -253,6 +253,45 @@ func update_camera_visibility():
 		fpp_camera.current = is_fpp
 		tpp_camera.current = not is_fpp
 
+
+##################################################################################################################
+######      Documentation about synchronising weapon models into multiplayer game in a correct way          ######
+##################################################################################################################
+
+## - To prevent the bug where let's say you have 2 player in the multiplayer room, 'Player 1' clicked the key 
+##   bind '1' --> that weapon model shows on both 'Player 1' and 'Player 2' character model, but not for the 
+##   'Player 2's screen, STRICTLY follow the instruction below to not letting that happens again (I have already 
+##   fix it):
+##
+##		+ Add new weapon models into the 'Player Scene Tree' (the thing on your left if you don't know the term 
+##		  for it) under each of the view mode: TPP and FPP (remember to re-name them as how the naming is written 
+##		  inside each view mode). 
+##
+##		  **If you unsure on how to add new weapon models into the 'Player Scene Tree', have a look at the 
+##		  'world.gd' file and read the documentation in there. It's very detailise and it should help you to be 
+##		  able to achieve this action (although it's not related to the weapon models, but it should be similar 
+##		  about the node setup).**
+##
+##		+ Then, click on the 'MultiplayerSynchronizer' Node (at the end of the 'Player Scene Tree') or click on 
+##		  the 'Replication' section (right at the bottom of your eye view if you don't see it)
+##
+##		+ After that, click on the 'Add property to sync...' button (It's the big ass '+' symbol if you don't see 
+##		  it).
+##
+##		+ After you clicked the button, it'll pop-up and show you the 'Player Scene Tree'. Don't be panic about 
+##		  all of the stuff in there yet, this documentation is where your life'll be easier. Clicks on your new 
+##		  weapon model (both TPP and FPP view mode, do it one by one because Godot won't let you to be a 'I'm ##		  fast as fuck boiz').
+##
+##		+ After you clicked the new weapon model respectively, it'll pop-up and show you all the options that you ##		  can choose to synchronise across all player. It's alright if you don't get wtf it's happening in 
+##		  there, just mindlessly follow this upcoming step to have a happy dev life (you can test out the other ##		  options on your own if you wanted to). Clicks on the 'visible' property (it's under the 'Node3D' 
+##		  section if you don't see it), and do the same for your new weapon models in both view mode.
+##
+##		+ You have officially made it if you followed the step correctly up to this point. Hooray!
+
+##################################################################################################################
+######             End of the Documentation. You may freely to continue working on this now!                ######
+##################################################################################################################
+
 # Update the visibility of guns when player changed the camera view based on their preferrance
 func update_weapon_model_visibility():
 	#print("Updating weapon model visibility")

--- a/Player.gd
+++ b/Player.gd
@@ -254,7 +254,7 @@ func update_camera_visibility():
 
 # Update the visibility of guns when player changed the camera view based on their preferrance
 func update_weapon_model_visibility():
-	print("Updating weapon model visibility")
+	#print("Updating weapon model visibility")
 
 	# Hide all weapon models
 	fpp_pistol.visible = false
@@ -283,10 +283,10 @@ func update_weapon_model_visibility():
 				else:
 					tpp_knife.visible = true
 
-	print("FPP Pistol Visible: ", fpp_pistol.visible)
-	print("FPP AK47 Visible: ", fpp_ak47.visible)
-	print("FPP Knife Visible: ", fpp_knife.visible)
-
-	print("TPP Pistol Visible: ", tpp_pistol.visible)
-	print("TPP AK47 Visible: ", tpp_ak47.visible)
-	print("TPP Knife Visible: ", tpp_knife.visible)
+	#print("FPP Pistol Visible: ", fpp_pistol.visible)
+	#print("FPP AK47 Visible: ", fpp_ak47.visible)
+	#print("FPP Knife Visible: ", fpp_knife.visible)
+#
+	#print("TPP Pistol Visible: ", tpp_pistol.visible)
+	#print("TPP AK47 Visible: ", tpp_ak47.visible)
+	#print("TPP Knife Visible: ", tpp_knife.visible)

--- a/models/characters/normal_declan.tscn
+++ b/models/characters/normal_declan.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=22 format=3 uid="uid://c6xxkytlbq8q2"]
 
 [ext_resource type="Script" path="res://Player.gd" id="1_ksfbt"]
-[ext_resource type="PackedScene" uid="uid://rge2rmqaquqm" path="res://models/characters/templateCharaterModel.glb" id="2_u05fy"]
-[ext_resource type="Texture2D" uid="uid://qna0vv6te2xs" path="res://addons/kenney_animated_characters/Skins/skaterMaleA.png" id="3_rtgxh"]
+[ext_resource type="PackedScene" uid="uid://cvey477smqw71" path="res://models/characters/templateCharaterModel.glb" id="2_u05fy"]
+[ext_resource type="Texture2D" uid="uid://c06olyt7bapq1" path="res://addons/kenney_animated_characters/Skins/skaterMaleA.png" id="3_rtgxh"]
 [ext_resource type="PackedScene" uid="uid://cf1dcxwv6bvl3" path="res://models/Pistol.glb" id="3_w7dyo"]
 [ext_resource type="Texture2D" uid="uid://vwob30tkwej4" path="res://addons/kenney_particle_pack/star_06.png" id="4_8wo5q"]
 [ext_resource type="Script" path="res://models/characters/FPPCamera.gd" id="4_huefa"]
@@ -295,6 +295,24 @@ properties/2/replication_mode = 1
 properties/3/path = NodePath("TPPCamera:rotation")
 properties/3/spawn = true
 properties/3/replication_mode = 1
+properties/4/path = NodePath("FPPCamera/FPPPistol:visible")
+properties/4/spawn = true
+properties/4/replication_mode = 1
+properties/5/path = NodePath("FPPCamera/FPPAK47:visible")
+properties/5/spawn = true
+properties/5/replication_mode = 1
+properties/6/path = NodePath("FPPCamera/FPPKnife:visible")
+properties/6/spawn = true
+properties/6/replication_mode = 1
+properties/7/path = NodePath("TPPCamera/TPPPistol:visible")
+properties/7/spawn = true
+properties/7/replication_mode = 1
+properties/8/path = NodePath("TPPCamera/TPPAK47:visible")
+properties/8/spawn = true
+properties/8/replication_mode = 1
+properties/9/path = NodePath("TPPCamera/TPPKnife:visible")
+properties/9/spawn = true
+properties/9/replication_mode = 1
 
 [node name="Player2" type="CharacterBody3D"]
 transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0, 0)

--- a/models/weapons/guns/ak47/ak47.tscn
+++ b/models/weapons/guns/ak47/ak47.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://ctdhwjuqvh51r"]
 
-[ext_resource type="PackedScene" uid="uid://cxcbmi5x2gygw" path="res://models/weapons/guns/ak47/ak47.fbx" id="1_jqpvt"]
-[ext_resource type="Texture2D" uid="uid://bacnhd30qp6d7" path="res://models/weapons/guns/ak47/texture_ak47.png" id="2_a2lhh"]
+[ext_resource type="PackedScene" uid="uid://c4tp4auj602lb" path="res://models/weapons/guns/ak47/ak47.fbx" id="1_jqpvt"]
+[ext_resource type="Texture2D" uid="uid://csey4nlfqpavg" path="res://models/weapons/guns/ak47/texture_ak47.png" id="2_a2lhh"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_2ca5y"]
 albedo_texture = ExtResource("2_a2lhh")

--- a/world.gd
+++ b/world.gd
@@ -5,18 +5,47 @@ extends Node
 @onready var hud = $CanvasLayer/HUD
 @onready var health_bar = $CanvasLayer/HUD/HealthBar
 
+##################################################################################################################
+######                          Documentation about using different type of characters                      ######
+##################################################################################################################
 
-## Documentation about using different type of characters
-##
 ## - This one down here is the original code to make that happens:
 ##		const Player = preload("res://player.tscn")
 ##
-## - For any new character models, inherance the 'normal_declan.tscn' file and change the 
-##   'Albedo' texture + adjust the animation in 'AnimationPlayer' node (if needed).
+## - For any new character models, inherance the 'normal_declan.tscn' file. Then, change the 
+##   'Albedo' texture: 
+
+##		(click on the model in 'Scene Tree' --> expand it out and find the 'MeshInstance3D' Node (the box-looking 
+##		symbol if you don't know the term for it) --> click on it -->  click on the 'Geometry' drop-down option
+##		--> click on 'Material Override' drop-down option --> choose 'New StandardMaterial3D' option --> expand 
+##		it out and find 'Albedo' drop-down option --> click on it and find 'Texture' option --> drag your .png 
+##		(or .jpg, or .jpeg [.webp won't work, you'll have to convert it using any online tools]) file that comes 
+##		with the .fbx file into this option --> (if the texture not loaded properly after you dragged it in, 
+##		enable the 'Texture Force sRGB' button. It should fix it. If not, try the 'Texture MSDF' button) --> 
+##		done!)  
+
+## - After you finish doing all of that, adjust the animation in 'AnimationPlayer' node (if the model does comes 
+##   with animation).
 ##
 ## - Then, preload that new model as below:
 ##		const Player = preload("res://models/characters/<model-name>.tscn")
+##
+##		**Applied the same concept for any new weapon models, right click on the .fbx file and click on the 'New 
+##		Inherited Scene' button. Then, re-name the 'Node' name in the 'Weapon Scene Tree' (the thing on your left 
+##		if you don't know the term for it) into the correct name that reflect the new model you added in this 
+##		project. After that, use 'Ctrl + S' combinantion key bind or right click on the '[unsaved]' scene (right 
+##		at the top of your eye view if you don't see it), and click 'Save Scene As...' button (for the 'right 
+##		click' method), or rename the .tscn file, which Godot given you when you try to save with the combination 
+##		key bind, into the correct naming that reflect the new weapon model you added in this project. Put them 
+##		into to somewhere that you think it's easy to navigate for you and everyone. Then, you can follow the 
+##		step to inherance the new weapon's .tscn file into the 'Chacracter Scene Tree' just right above this 
+##		comment. Although it's not directly for the character model, but it should relavantly the same setup that 
+##		you can follow through. At this point, you have successfully done this if you follow the step correctly. 
+##		Hooray!**
 
+##################################################################################################################
+######             End of the Documentation. You may freely to continue working on this now!                ######
+##################################################################################################################
 
 const Player = preload("res://models/characters/normal_declan.tscn")
 const PORT = 9999


### PR DESCRIPTION
I've also include documentation on how to easily do this without causing the bug again. Consider reading them when you do any stuffs that related to weapon models in general and any other models in particular.